### PR TITLE
Fix issue #2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,3 +36,10 @@ add_subdirectory(external/SFML)
 target_include_directories(${PROJECT_NAME} PUBLIC external/SFML/include)
 target_link_directories(${PROJECT_NAME} PUBLIC external/SFML/lib)
 target_link_libraries(${PROJECT_NAME} sfml-graphics sfml-window sfml-system)
+
+# Copy model to build directory
+add_custom_command(
+    TARGET ${PROJECT_NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_SOURCE_DIR}/model
+        ${CMAKE_CURRENT_BINARY_DIR}/model)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Since this project is using [SFML](https://www.sfml-dev.org/), you will need fol
 Then run following commands in project directory:
 
     mkdir build && cd build
-    ln -s ../model .  # Make example model available
     cmake ..
     make
 


### PR DESCRIPTION
Closes #2 
Instead of bothering user to enter asset paths, CMake can copy assets directly to build directory.